### PR TITLE
Remove GraphQL Playground in favor of new Apollo Client Sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,21 +160,6 @@
                 "graphql": "14.x || 15.x || 16.x"
             }
         },
-        "node_modules/@apollo/server-plugin-landing-page-graphql-playground": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-            "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-            "deprecated": "The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.",
-            "dependencies": {
-                "@apollographql/graphql-playground-html": "1.6.29"
-            },
-            "engines": {
-                "node": ">=14.0"
-            },
-            "peerDependencies": {
-                "@apollo/server": "^4.0.0"
-            }
-        },
         "node_modules/@apollo/usage-reporting-protobuf": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
@@ -314,14 +299,6 @@
             "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/@apollographql/graphql-playground-html": {
-            "version": "1.6.29",
-            "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-            "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-            "dependencies": {
-                "xss": "^1.0.8"
             }
         },
         "node_modules/@ardatan/relay-compiler": {
@@ -5880,11 +5857,6 @@
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
         },
-        "node_modules/cssfilter": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-        },
         "node_modules/dataloader": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -11361,26 +11333,6 @@
                 }
             }
         },
-        "node_modules/xss": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-            "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-            "dependencies": {
-                "commander": "^2.20.3",
-                "cssfilter": "0.0.10"
-            },
-            "bin": {
-                "xss": "bin/xss"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/xss/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -11526,7 +11478,6 @@
             "version": "0.0.1",
             "dependencies": {
                 "@apollo/server": "^4.7.5",
-                "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
                 "@ftc-scout/common": "^0.0.1",
                 "@graphql-tools/schema": "^10.0.0",
                 "canvas": "^2.11.2",
@@ -11766,14 +11717,6 @@
                 "@apollo/utils.logger": "^2.0.0"
             }
         },
-        "@apollo/server-plugin-landing-page-graphql-playground": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-            "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-            "requires": {
-                "@apollographql/graphql-playground-html": "1.6.29"
-            }
-        },
         "@apollo/usage-reporting-protobuf": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
@@ -11864,14 +11807,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
             "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA=="
-        },
-        "@apollographql/graphql-playground-html": {
-            "version": "1.6.29",
-            "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-            "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-            "requires": {
-                "xss": "^1.0.8"
-            }
         },
         "@ardatan/relay-compiler": {
             "version": "12.0.0",
@@ -12880,7 +12815,6 @@
             "version": "file:packages/server",
             "requires": {
                 "@apollo/server": "^4.7.5",
-                "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
                 "@flydotio/dockerfile": "^0.4.10",
                 "@ftc-scout/common": "^0.0.1",
                 "@graphql-tools/schema": "^10.0.0",
@@ -15911,11 +15845,6 @@
                 "mdn-data": "2.0.30",
                 "source-map-js": "^1.0.1"
             }
-        },
-        "cssfilter": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "dataloader": {
             "version": "2.2.2",
@@ -19863,22 +19792,6 @@
             "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
             "dev": true,
             "requires": {}
-        },
-        "xss": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-            "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-            "requires": {
-                "commander": "^2.20.3",
-                "cssfilter": "0.0.10"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-                }
-            }
         },
         "xtend": {
             "version": "4.0.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,6 @@
     },
     "dependencies": {
         "@apollo/server": "^4.7.5",
-        "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
         "@ftc-scout/common": "^0.0.1",
         "@graphql-tools/schema": "^10.0.0",
         "canvas": "^2.11.2",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,7 +8,6 @@ import compression from "compression";
 import { apiLoggerMiddleware } from "./db/entities/ApiReq";
 import { SERVER_PORT, SYNC_API } from "./constants";
 import { ApolloServer } from "@apollo/server";
-import { ApolloServerPluginLandingPageGraphQLPlayground } from "@apollo/server-plugin-landing-page-graphql-playground";
 import { expressMiddleware } from "@apollo/server/express4";
 import { GQL_SCHEMA } from "./graphql/schema";
 import { fetchPriorSeasons, watchApi } from "./ftc-api/watch";
@@ -55,7 +54,6 @@ async function main() {
             ttl: 120, // 2 minutes
         }),
         plugins: [
-            ApolloServerPluginLandingPageGraphQLPlayground(),
             ApolloServerPluginDrainHttpServer({ httpServer }),
             {
                 async serverWillStart() {

--- a/packages/web/src/routes/api/+page.svelte
+++ b/packages/web/src/routes/api/+page.svelte
@@ -46,7 +46,7 @@
 
             <h2>REST</h2>
             <p>
-                The REST API is best used for simpler cases. It is not used internally, and this it
+                The REST API is best used for simpler cases. It is not used internally, and thus it
                 doesn't provide access to all of our data. For example, you can't perform season
                 record queries using it. However, if you just need team data, match data, or single
                 event statistics, it provides an easy way to access those.


### PR DESCRIPTION
This solves #9 .

GraphQL Playground was deprecated as a result of lack of maintenance and vulnerabilities. As a result, it uses features that are no longer supported in modern browsers such as Chrome. This causes a lack of usability in some cases.

This fix removes the legacy plugin that provides the playground in favor of the Apollo Client-recommended "Sandbox." The Sandbox uses introspection to deliver the entire schema, and provides additional features the old client did not have, such as integrations with a user's Apollo Client account, which is useful for development. It also displays the schema in a more human-readable way.

This PR also contains a spelling fix (this → thus).

_Note: This PR was re-made to fix a [mistake](https://discord.com/channels/1040852718195052586/1040852719382048883/1391568194631897190) I made w/ Git_