### PR TITLE
exclude matches where all teams are surrogates from records

### DIFF
--- a/packages/server/src/db/entities/Event.ts
+++ b/packages/server/src/db/entities/Event.ts
@@ -19,6 +19,12 @@ export type EventLivestreamDay = {
 
 type EventLivestreamOverrides = Partial<Record<Season, Record<string, EventLivestreamDay[]>>>;
 
+export const MODIFIED_RULES_EVENTS = [
+    // cspell:disable
+    "USTXCECCS",
+    // cspell:enable
+];
+
 @Entity()
 export class Event extends BaseEntity {
     @PrimaryColumn("smallint")
@@ -195,12 +201,6 @@ export class Event extends BaseEntity {
             return event_name;
         }
 
-        const MODIFIED_RULES = [
-            // cspell:disable
-            "USTXCECCS",
-            // cspell:enable
-        ];
-
         const MODIFIED_REGION_CODES: Record<string, RegionCode> = {
             NE: RegionCode.USNE,
         };
@@ -370,7 +370,7 @@ export class Event extends BaseEntity {
             timezone: api.timezone === "Asia/Calcutta" ? "Asia/Kolkata" : api.timezone ?? "UTC",
             start: new Date(api.dateStart),
             end: new Date(api.dateEnd),
-            modifiedRules: MODIFIED_RULES.indexOf(api.code) != -1,
+            modifiedRules: MODIFIED_RULES_EVENTS.indexOf(api.code) != -1,
         } satisfies DeepPartial<Event>);
     }
 }

--- a/packages/server/src/db/entities/Match.ts
+++ b/packages/server/src/db/entities/Match.ts
@@ -16,7 +16,7 @@ import {
     PrimaryColumn,
     UpdateDateColumn,
 } from "typeorm";
-import { Event } from "./Event";
+import { Event, MODIFIED_RULES_EVENTS } from "./Event";
 import { DateTime } from "luxon";
 import { MatchScore } from "./dyn/match-score";
 import { TeamMatchParticipation } from "./TeamMatchParticipation";
@@ -57,6 +57,9 @@ export class Match extends BaseEntity {
 
     @Column("smallint")
     series!: number;
+
+    @Column()
+    modifiedRules!: boolean;
 
     get matchNum(): number {
         return this.id % 1000;
@@ -116,6 +119,8 @@ export class Match extends BaseEntity {
                 : null,
             tournamentLevel,
             series,
+            modifiedRules:
+                api.teams.every((t) => t.surrogate) || MODIFIED_RULES_EVENTS.includes(event.code),
         } satisfies DeepPartial<Match>);
     }
 

--- a/packages/server/src/db/entities/Match.ts
+++ b/packages/server/src/db/entities/Match.ts
@@ -16,7 +16,7 @@ import {
     PrimaryColumn,
     UpdateDateColumn,
 } from "typeorm";
-import { Event, MODIFIED_RULES_EVENTS } from "./Event";
+import { Event } from "./Event";
 import { DateTime } from "luxon";
 import { MatchScore } from "./dyn/match-score";
 import { TeamMatchParticipation } from "./TeamMatchParticipation";
@@ -99,7 +99,6 @@ export class Match extends BaseEntity {
             allMatches
         );
         tournamentLevel = tournamentLevel_;
-
         return Match.create({
             eventSeason: event.season,
             eventCode: event.code,
@@ -119,8 +118,7 @@ export class Match extends BaseEntity {
                 : null,
             tournamentLevel,
             series,
-            modifiedRules:
-                api.teams.every((t) => t.surrogate) || MODIFIED_RULES_EVENTS.includes(event.code),
+            modifiedRules: api.teams.every((t) => t.surrogate) || event.modifiedRules,
         } satisfies DeepPartial<Match>);
     }
 

--- a/packages/server/src/db/loaders/load-all-matches.ts
+++ b/packages/server/src/db/loaders/load-all-matches.ts
@@ -116,6 +116,16 @@ export async function loadAllMatches(season: Season, loadType: LoadType) {
                 );
             });
 
+            // if all teams are surrogates, or the event has modded rules, then the match is modified rules
+            updatedMatches.forEach((m) => {
+                if (m.teams.every((t) => t.surrogate)) {
+                    m.modifiedRules = true;
+                }
+                if (event.modifiedRules) {
+                    m.modifiedRules = true;
+                }
+            });
+
             publishMatchUpdates(updatedMatches);
 
             console.info(`Loaded ${i + 1}/${events.length}.`);

--- a/packages/server/src/db/loaders/load-all-matches.ts
+++ b/packages/server/src/db/loaders/load-all-matches.ts
@@ -116,16 +116,6 @@ export async function loadAllMatches(season: Season, loadType: LoadType) {
                 );
             });
 
-            // if all teams are surrogates, or the event has modded rules, then the match is modified rules
-            updatedMatches.forEach((m) => {
-                if (m.teams.every((t) => t.surrogate)) {
-                    m.modifiedRules = true;
-                }
-                if (event.modifiedRules) {
-                    m.modifiedRules = true;
-                }
-            });
-
             publishMatchUpdates(updatedMatches);
 
             console.info(`Loaded ${i + 1}/${events.length}.`);
@@ -166,7 +156,7 @@ async function eventsToFetch(season: Season, loadType: LoadType) {
     if (loadType == LoadType.Full) {
         return DATA_SOURCE.getRepository(Event)
             .createQueryBuilder("e")
-            .select(["e.season", "e.code", "e.remote", "e.timezone"])
+            .select(["e.season", "e.code", "e.remote", "e.timezone", "e.modifiedRules"])
             .distinct(true)
             .leftJoin(Match, "m", "e.season = m.event_season AND e.code = m.event_code")
             .leftJoin(
@@ -182,7 +172,7 @@ async function eventsToFetch(season: Season, loadType: LoadType) {
     } else {
         return DATA_SOURCE.getRepository(Event)
             .createQueryBuilder("e")
-            .select(["e.season", "e.code", "e.remote", "e.timezone"])
+            .select(["e.season", "e.code", "e.remote", "e.timezone", "e.modifiedRules"])
             .distinct(true)
             .where("season = :season", { season })
             .andWhere("start <= (NOW() at time zone timezone)::date")

--- a/packages/server/src/graphql/resolvers/Home.ts
+++ b/packages/server/src/graphql/resolvers/Home.ts
@@ -97,44 +97,13 @@ async function getWorldRecordMatch(
             "s.season = m.event_season AND s.event_code = m.event_code AND s.match_id = m.id"
         )
         .leftJoin(Event, "e", "e.season = m.event_season AND e.code = m.event_code")
-        .leftJoin(
-            "team_match_participation",
-            "tmp1",
-            `s.season = tmp1.season AND s.event_code = tmp1.event_code AND s.match_id =
-            tmp1.match_id AND s.alliance = tmp1.alliance AND (tmp1.station = 'Solo' OR
-            tmp1.station = 'One')`
-        )
-        .leftJoin(
-            "team_match_participation",
-            "tmp2",
-            `s.season = tmp2.season AND s.event_code = tmp2.event_code AND s.match_id =
-            tmp2.match_id AND s.alliance = tmp2.alliance AND tmp2.station = 'Two'`
-        )
-        .leftJoin(
-            "team_match_participation",
-            "tmp1Opp",
-            `s.season = tmp1Opp.season AND s.event_code = tmp1Opp.event_code AND s.match_id =
-            tmp1Opp.match_id AND s.alliance <> tmp1Opp.alliance AND tmp1Opp.station = 'One'`
-        )
-        .leftJoin(
-            "team_match_participation",
-            "tmp2Opp",
-            `s.season = tmp2Opp.season AND s.event_code = tmp2Opp.event_code AND s.match_id =
-            tmp2Opp.match_id AND s.alliance <> tmp2Opp.alliance AND tmp2Opp.station = 'Two'`
-        )
         .orderBy(orderColumn, "DESC")
         .where("m.has_been_played")
         .andWhere("NOT e.remote")
         .andWhere("e.type <> 'OffSeason'")
         .andWhere("NOT e.modified_rules")
+        .andWhere("NOT m.modified_rules")
         .andWhere('m."event_season" = :season', { season })
-        // Exclude matches where all four teams (both alliances) were surrogates.
-        .andWhere(
-            `NOT (
-                COALESCE(tmp1.surrogate, false) AND COALESCE(tmp2.surrogate, false) AND
-                COALESCE(tmp1Opp.surrogate, false) AND COALESCE(tmp2Opp.surrogate, false)
-            )`
-        )
         .limit(1)
         .getOne();
 

--- a/packages/server/src/graphql/resolvers/Home.ts
+++ b/packages/server/src/graphql/resolvers/Home.ts
@@ -97,12 +97,44 @@ async function getWorldRecordMatch(
             "s.season = m.event_season AND s.event_code = m.event_code AND s.match_id = m.id"
         )
         .leftJoin(Event, "e", "e.season = m.event_season AND e.code = m.event_code")
+        .leftJoin(
+            "team_match_participation",
+            "tmp1",
+            `s.season = tmp1.season AND s.event_code = tmp1.event_code AND s.match_id =
+            tmp1.match_id AND s.alliance = tmp1.alliance AND (tmp1.station = 'Solo' OR
+            tmp1.station = 'One')`
+        )
+        .leftJoin(
+            "team_match_participation",
+            "tmp2",
+            `s.season = tmp2.season AND s.event_code = tmp2.event_code AND s.match_id =
+            tmp2.match_id AND s.alliance = tmp2.alliance AND tmp2.station = 'Two'`
+        )
+        .leftJoin(
+            "team_match_participation",
+            "tmp1Opp",
+            `s.season = tmp1Opp.season AND s.event_code = tmp1Opp.event_code AND s.match_id =
+            tmp1Opp.match_id AND s.alliance <> tmp1Opp.alliance AND tmp1Opp.station = 'One'`
+        )
+        .leftJoin(
+            "team_match_participation",
+            "tmp2Opp",
+            `s.season = tmp2Opp.season AND s.event_code = tmp2Opp.event_code AND s.match_id =
+            tmp2Opp.match_id AND s.alliance <> tmp2Opp.alliance AND tmp2Opp.station = 'Two'`
+        )
         .orderBy(orderColumn, "DESC")
         .where("m.has_been_played")
         .andWhere("NOT e.remote")
         .andWhere("e.type <> 'OffSeason'")
         .andWhere("NOT e.modified_rules")
         .andWhere('m."event_season" = :season', { season })
+        // Exclude matches where all four teams (both alliances) were surrogates.
+        .andWhere(
+            `NOT (
+                COALESCE(tmp1.surrogate, false) AND COALESCE(tmp2.surrogate, false) AND
+                COALESCE(tmp1Opp.surrogate, false) AND COALESCE(tmp2Opp.surrogate, false)
+            )`
+        )
         .limit(1)
         .getOne();
 

--- a/packages/server/src/graphql/resolvers/Match.ts
+++ b/packages/server/src/graphql/resolvers/Match.ts
@@ -32,6 +32,7 @@ export const MatchGQL: GraphQLObjectType = new GraphQLObjectType({
         description: StrTy,
         createdAt: DateTimeTy,
         updatedAt: DateTimeTy,
+        modifiedRules: BoolTy,
 
         // Must use aware loader
         scores: {


### PR DESCRIPTION
events (notably CPE) mark matches with special rules by marking all teams as surrogates

this is so that the world record match on the homepage is not a match with modified rules